### PR TITLE
removed config_common.h from config.h

### DIFF
--- a/config.h
+++ b/config.h
@@ -19,8 +19,6 @@
 //#define NO_ACTION_TAPPING
 //#define NO_ACTION_ONESHOT
 
-#include "config_common.h"
-
 // ┌─────────────────────────────────────────────────┐
 // │ s p l i t   c o m m u n i c a t i o n           │
 // └─────────────────────────────────────────────────┘


### PR DESCRIPTION
config_common.h shouldn't be present anymore as it has been removed per these change logs: https://github.com/qmk/qmk_firmware/blob/4bcc80ad464c413ec1e27670638bda8e35a505f9/docs/ChangeLog/20230528.md?plain=1#L14 